### PR TITLE
Adds code to, theoretically, insert a drag-n-drop disk image.

### DIFF
--- a/src/sdl2_driver.c
+++ b/src/sdl2_driver.c
@@ -384,6 +384,14 @@ check_input_events_sdl()
 				SDL_Quit();
 				my_exit(1);
 				break;
+			case SDL_DROPFILE:
+				{
+				char *file = event.drop.file;
+				cfg_inspect_maybe_insert_file(file, 0);
+				SDL_free(file);
+				}
+				break;
+
 			default:
 				break;
 		}


### PR DESCRIPTION
This is only a theory since SDL2 or OS X 10.12 seem to have a nasty bug where drag-n-drop overfrees some memory and crashes (which happens even without this code in place).
