### PR TITLE
Porting kegs-universal changes to gsplus.

### DIFF
--- a/doc/kegs-universal.md
+++ b/doc/kegs-universal.md
@@ -1,0 +1,179 @@
+# kegs-universal
+
+Minimal changes on the kegs apple2-gs emulator to accept and run  apple 2, 2+, 2e, 2c, and 2c+ roms.
+
+
+I was curious to see how difficult it would be to boot the KEGS Apple 2gs emulator 
+using the ROMs of older Apple 2 models. Since the 2gs hardware was designed to be
+as compatible as possible with the earlier models, it likely supports what the 
+older ROMs need. This reasoning worked quite well for the Apple 2, 2+, 
+and 2e ROMs. The changes needed to support the Apple 2c and 2c+ ROMs were 
+much more interesting. This is described below.
+
+## Supported ROMs
+
+The KEGS configuration code (`config.c`) was minimally changed to accept ROM
+files of 12KB (for the Apple 2 and 2+), 16KB (for the Apple 2e and some 2c),
+32KB (for the Apple 2c and 2c+). It also uses the standard tests to
+determine the type of the machine associated with the ROM and
+set the variable `g_a2rom_version` with the following values:
+  * `'2'` for an Apple 2 or Apple 2+ ROM (both 12KB roms,)
+  * `'e'` for an Apple 2e (both the 16KB original and enhanced roms,)
+  * `'c'` for an Apple 2c  (tested the 16KB rom0 and the 32KB rom4,)
+  * `'C'` for an Apple 2c+ (the 32KB rom5,)
+  * `'g'` for an Apple 2gs (both the 128KB and 256KB roms.)
+
+I also added a configuration option to load the disk controller ROM
+into the slot 6 rom space. This is useful with the 2, 2+, and 2e ROMs.
+The 2c, 2c+, and 2gs ROMs provide this code.
+
+## Apple 2 and 2+
+
+The Apple 2 and 2+ ROMs booted right away.
+For convenience I added code in `moremem.c` to map all alpha keys to uppercase
+and to map the delete key to backspace. I also noticed and fixed subtle but
+important differences over time:
+  * The 2gs resets the banked memory in a known state at every reset. 
+    The original language card settings were preserved. The reset code
+    in file `sim65816.c` now selectively initializes registers
+    depending on the detected rom type.
+  * The 2gs contains a special circuit that causes the processor to
+    always fetch interruption vectors in the rom located in page `ff` 
+    instead of page `00`. The corresponding code, located in `sim65816.c`,
+    now only does this if `g_a2rom_version=='g'`.
+  * The KEGS emulator did not implement the language card memory protection
+    and the double reading of the `c08x`. This was fixed in `moremem.c`
+    for all architectures. A couple weeks later I also had to modify the
+    cpu simulation code for INC abs,X because several pieces of code depend
+    on the 6502/65C02/65816 reading the memory location twice to write-enable
+    the language card ram.
+    
+Note that the character generator ROM still shows characters `e0..ff`
+as lowercase character. On the real Apple 2 or 2+, these are uppercase
+characters.
+
+## Apple 2e
+
+The Apple 2e ROMs also booted right away and even passed the self test.
+This is not surprising as the 2gs is designed to be maximally 
+compatible with the 2e.
+
+## Apple 2c
+
+Getting the Apple 2c to work represented a lot more work.
+It turns out that the 2e and the 2c often follow different paths
+to remain compatible with the original Apple 2. For instance,
+in the 2e or the 2gs, reading `c019` merely tells you whether
+we are in the video vertical blanking time window. On the 2c,
+this same register tells you whether there is a pending vertical
+blanking interrupt and clears the interrupt. All these details
+are fixed in `moremem.c`.
+
+### Rombank
+
+The later Apple 2c ROMS contain 32KB of code. The config file
+loads the two 16KB segments in the 2gs pages `ff` and `fe`.
+Which ROM bank is shown in page `00` then depends
+on the RDROM, CXINT, and ROMBANK bits of the `c068` state
+register. The KEGS emulator did not support the ROMBANK
+bit and I implemented it to use the rom from page `fe` 
+instead of `ff`. The Apple 2c port `c028` now
+switches the active bank by calling the normal
+function `set_statereg()` defined in `moremem.c`.
+
+### Slinky
+
+The later Apple 2c also support a memory expansion card
+that can be used as a virtual drive. It turns out that
+some versions of the 2c ROMs do not boot properly when
+the corresponding i/o ports `c0cx` are not implemented.
+Simple code in `moremem.c` now uses up to 1MB of RAM
+in pages `02` to `12` to implement the memory extension.
+
+### The Apple 2c mouse
+
+Then I decided to resolve the dramatically different ways 
+in which the 2c and the 2gs handle the mouse. Whereas the 2gs 
+uses the rather intelligent adb controller to buffer the mouse 
+moves and report x or y deltas in range 0..64, the 2c interrupts 
+the 65C02 for every little move. Each access to an Apple 2c
+mouse register now calls a routine that pumps the mouse state
+from the 2gs adb controller (function `emulate_a2c_mouse()` in 
+file `moremem.c`). In parallel, two small changes in `adb.c` were 
+necessary in order to send mouse deltas in smaller increments
+and to prevent the 2gs from interrupting the cpu
+when the mouse button is pressed without mouse move.
+Prodos really dislikes unhandled interrupts.
+
+### Serial ports
+
+I did not try to emulate the ACIA or map it to the 2gs SCC.
+
+### 3.5" drives.
+
+Later version of the Apple 2c also supports 3.5" drives.
+However these are not the same as the 2gs 3.5" drives.
+The 2c only uses the Unidisk 3.5" that contain
+their own 6502 variant clocked at 2MHz, that is
+twice faster than the 2c 65C02 cpu.  The proper way
+to implement this would be to have the emulator
+intercept firmware calls on slot 5. This technique
+is already used by Kegs to simulate a hard disk
+on slot 7. On the other hand, the 2c+ uses the
+same drives as the 2gs...
+
+## Apple 2c+
+
+Surprisingly the changes that made the late Apple 2c ROMs 
+work smoothly allowed KEGS to boot the Apple 2c+ ROM and
+even pass the self test. 
+
+Then I came with the crazy idea to make the 2gs 3.5" drives
+work with the Apple 2c+ ROM. This can work because the
+Apple 2c+ uses the same dumb 3.5" drives as the 2gs.
+The difficult is that the Apple 2c+ does so using
+the special and poorly documented MIG chip and
+using a small 2K cache RAM.  
+
+The MIG is rumored to be necessary to allow the 1MHz 65C02 to 
+keep up with the 3.5" drive data transfer rate. The rumor
+says that the Apple engineers only kept the MIG on the 2c+ board
+because the 4MHz built-in cpu accelerator was a late addition
+to the project. The only programming information I found
+on the MIG was some 
+[reverse engineering by "M.G."](http://apple2.guidero.us/doku.php?id=mg_notes:apple_iic:mig_chip)
+and the discussion following a 
+[bug report for the MAME emulator.](https://github.com/mamedev/mame/issues/2775)
+
+Two realization helped me figure out the rest. First, in the available
+2c schematics, the MIG RESET line is tied to both the /IOSEL line 
+and the A14 ROM line which selects the alternate 16KB ROM bank.
+In other words, the MIG can only be accessed when the alternate
+ROM bank is selected. Whenever the firmware returns to the main ROM bank,
+the MIG is reset to its default, 5.25" inch drive-compatible, state.
+This is probably why M.G. only saw brief pulses on the drive lines
+when triggering the MIG i/o ports.  The second realization was
+that the Apple 2c+ supports three dumb 3.5" drives: the internal drive
+and two external daisy chained drives. The MIG contains a switch
+that either directs the IWM DR2 enable to the internal disk
+or to the external port. This makes the internal disk a d2
+while the external disks are d1 and d2. After figuring out
+how the MIG i/o ports control this switch as well as the 
+3.5SEL and HDSEL lines, I had the tricky problem to remap
+the internal d2 and the external d1 onto the two external d1 and
+d2 drives implemented by KEGS. This is all implemented
+in file `moremem.c`.
+    
+## Apple 2gs
+
+The behavior of KEGS with an Apple 2gs ROM is 
+mostly unchanged with the following three exceptions:
+  * The memory protection features of the banked language card memory
+    is now implemented.
+  * The slot 7 smartport hard disk emulation is now 
+    switched like the ROM of a virtual card inserted in slot 7.
+  * If the slot 7 code fails to find a bootable disk, the search
+    for a bootable disk continues with slots 6 and 5.
+   
+    
+  

--- a/src/.dir-locals.el
+++ b/src/.dir-locals.el
@@ -1,0 +1,9 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((c-mode
+  (c-basic-offset . 8))
+ (nil
+  (indent-tabs-mode . t)))
+
+

--- a/src/adb.c
+++ b/src/adb.c
@@ -32,6 +32,7 @@ extern word32 g_vbl_count;
 extern int g_num_lines_prev_superhires640;
 extern int g_num_lines_prev_superhires;
 extern int g_rom_version;
+extern int g_a2rom_version;
 extern int g_fast_disk_emul;
 extern int g_limit_speed;
 extern int g_irq_pending;
@@ -1257,7 +1258,10 @@ update_mouse(int x, int y, int button_states, int buttons_valid)
 		if( (g_mouse_ctl_addr == g_mouse_dev_addr) &&
 						((g_adb_mode & 0x2) == 0)) {
 			g_adb_mouse_valid_data = 1;
-			adb_add_mouse_int();
+			if (mouse_moved || g_a2rom_version == 'g')
+				/* A2C only interrupts on mouse move
+				   and Prodos8 does not like unexplained interrupts */
+				adb_add_mouse_int();
 		}
 	}
 
@@ -1267,6 +1271,13 @@ update_mouse(int x, int y, int button_states, int buttons_valid)
 int
 mouse_read_c024(double dcycs)
 {
+	return mouse_read_c024_clamp(dcycs, 0x3f);
+}
+
+int
+mouse_read_c024_clamp(double dcycs, int clamp)
+{
+
 	word32	ret;
 	word32	tool_start;
 	int	em_active;
@@ -1294,18 +1305,18 @@ mouse_read_c024(double dcycs)
 	delta_y = target_y - g_mouse_a2_y;
 
 	clamped = 0;
-	if(delta_x > 0x3f) {
-		delta_x = 0x3f;
+	if(delta_x > clamp) {
+		delta_x = clamp;
 		clamped = 1;
-	} else if(delta_x < -0x3f) {
-		delta_x = -0x3f;
+	} else if(delta_x < -clamp) {
+		delta_x = -clamp;
 		clamped = 1;
 	}
-	if(delta_y > 0x3f) {
-		delta_y = 0x3f;
+	if(delta_y > clamp) {
+		delta_y = clamp;
 		clamped = 1;
-	} else if(delta_y < -0x3f) {
-		delta_y = -0x3f;
+	} else if(delta_y < -clamp) {
+		delta_y = -clamp;
 		clamped = 1;
 	}
 

--- a/src/config.c
+++ b/src/config.c
@@ -166,7 +166,8 @@ char g_cfg_opts_strvals[CFG_MAX_OPTS][CFG_OPT_MAXSTR];
 char g_cfg_opt_buf[CFG_OPT_MAXSTR];
 
 char *g_cfg_rom_path = "ROM";
-char *g_cfg_c6rom_path = "c600.rom";
+char *g_cfg_c1rom_path = "parallel.rom";
+char *g_cfg_c6rom_path = "disk2.rom";
 char *g_cfg_file_def_name = "Undefined";
 char **g_cfg_file_strptr = 0;
 int g_cfg_file_min_size = 256;
@@ -230,6 +231,7 @@ Cfg_menu g_cfg_joystick_menu[] = {
 Cfg_menu g_cfg_rom_menu[] = {
 { "ROM File Selection", g_cfg_rom_menu, 0, 0, CFGTYPE_MENU },
 { "ROM File", KNMP(g_cfg_rom_path), CFGTYPE_FILE },
+{ "C100 ROM File", KNMP(g_cfg_c1rom_path), CFGTYPE_FILE },
 { "C600 ROM File", KNMP(g_cfg_c6rom_path), CFGTYPE_FILE },
 { "", 0, 0, 0, 0 },
 { "Back to Main Config", g_cfg_main_menu, 0, 0, CFGTYPE_MENU },
@@ -428,12 +430,12 @@ int g_cfg_file_pathfield = 0;
 const char *g_gsplus_rom_names[] = { "ROM", "ROM", "ROM.01", "ROM.03", 0 };
 	/* First entry is special--it will be overwritten by g_cfg_rom_path */
 
-const char *g_gsplus_c1rom_names[] = { "parallel.rom", 0 };
+const char *g_gsplus_c1rom_names[] = { "parallel.rom", "parallel.rom", 0 };
 const char *g_gsplus_c2rom_names[] = { 0 };
 const char *g_gsplus_c3rom_names[] = { 0 };
 const char *g_gsplus_c4rom_names[] = { 0 };
 const char *g_gsplus_c5rom_names[] = { 0 };
-const char *g_gsplus_c6rom_names[] = { "c600.rom", "c600.rom", "controller.rom", "disk.rom",
+const char *g_gsplus_c6rom_names[] = { "disk2.rom", "c600.rom", "controller.rom", "disk.rom",
 				"DISK.ROM", "diskII.prom", 0 };
 const char *g_gsplus_c7rom_names[] = { 0 };
 
@@ -832,6 +834,7 @@ config_load_roms()
 	/* set first entry of g_gsplus_rom_names[] to g_cfg_rom_path so that */
 	/*  it becomes the first place searched. */
 	g_gsplus_rom_names[0] = g_cfg_rom_path;
+	g_gsplus_rom_card_list[1][0] = g_cfg_c1rom_path;
 	g_gsplus_rom_card_list[6][0] = g_cfg_c6rom_path;
 	setup_gsplus_file(&g_cfg_tmp_path[0], CFG_PATH_MAX, -1, 0,
 							&g_gsplus_rom_names[0]);

--- a/src/defs_instr.h
+++ b/src/defs_instr.h
@@ -637,9 +637,12 @@ defs_instr_start_16	.word	0
 #  define GET_ABS_X_RD_WR()					\
 	GET_2BYTE_ARG;						\
 	INC_KPC_3;						\
-	CYCLES_PLUS_2;						\
+	CYCLES_PLUS_1;						\
+	tmp1 = (dbank<<16)+(arg&0xff00)+((arg+xreg)&0xff);	\
+	GET_MEMORY8(tmp1, tmp1);  /* popular double read */	\
+	CYCLES_PLUS_1;						\
 	arg = (dbank << 16) + ((arg + xreg) & 0xffff);		\
-	GET_MEMORY8(arg, arg);
+	GET_MEMORY8(arg, arg);		 
 # else
 #  define GET_ABS_X_RD()					\
 	GET_ABS_INDEX_ADDR_FOR_RD(xreg);			\
@@ -648,7 +651,10 @@ defs_instr_start_16	.word	0
 #  define GET_ABS_X_RD_WR()					\
 	GET_2BYTE_ARG;						\
 	INC_KPC_3;						\
-	CYCLES_PLUS_2;						\
+	CYCLES_PLUS_1;						\
+	tmp1 = (dbank<<16)+(arg&0xff00)+((arg+xreg)&0xff);	\
+	GET_MEMORY8(tmp1, tmp1);  /* popular double read */	\
+	CYCLES_PLUS_1;						\
 	arg = (dbank << 16) + ((arg + xreg) & 0xffff);		\
 	GET_MEMORY16(arg, arg, 0);
 # endif

--- a/src/iwm.c
+++ b/src/iwm.c
@@ -507,7 +507,7 @@ iwm_touch_switches(int loc, double dcycs)
 			break;
 		case 0xa:
 		case 0xb:
-			iwm.drive_select = on;
+			iwm.drive_select = mig_changedrive(on);
 			break;
 		case 0xc:
 		case 0xd:
@@ -515,6 +515,7 @@ iwm_touch_switches(int loc, double dcycs)
 			break;
 		case 0xe:
 		case 0xf:
+			mig_checkwhead(dsk, on); 
 			iwm.q7 = on;
 			break;
 		default:
@@ -2007,7 +2008,7 @@ iwm_nibblize_track_35(Disk *dsk, Trk *trk, byte *track_buf, int qtr_track)
 	}
 
 	phys_sec = 0;
-	interleave = 2;
+	interleave = (dsk->image_type == DSK_TYPE_35_4) ? 4 : 2;
 	for(log_sec = 0; log_sec < num_sectors; log_sec++) {
 		while(phys_to_log_sec[phys_sec] >= 0) {
 			phys_sec++;

--- a/src/iwm.h
+++ b/src/iwm.h
@@ -30,6 +30,9 @@
 #define DSK_TYPE_PRODOS		0
 #define DSK_TYPE_DOS33		1
 #define DSK_TYPE_NIB		2
+#define DSK_TYPE_35_4    	4   /* 3.5 disk with 1:4 interleave */
+
+
 
 typedef struct _Disk Disk;
 

--- a/src/moremem.c
+++ b/src/moremem.c
@@ -493,8 +493,9 @@ void moremem_init()
 	g_c041_val = 0;		/* C041_EN_25SEC_INTS, C041_EN_MOVE_INTS */
 	g_c046_val = 0;
 	g_c05x_annuncs = 0;
-	g_c068_statereg = 0;
+	g_c068_statereg = 0x0c;
 	g_c08x_wrdefram = 0;
+	g_c08x_q3defram = 0;
 	g_zipgs_unlock = 0;
 	g_zipgs_reg_c059 = 0x5f;
 	g_zipgs_reg_c05a = 0x0f;

--- a/src/protos.h
+++ b/src/protos.h
@@ -124,6 +124,7 @@ void write_adb_ram(word32 addr, int val);
 int adb_get_keypad_xy(int get_y);
 int update_mouse(int x, int y, int button_states, int buttons_valid);
 int mouse_read_c024(double dcycs);
+int mouse_read_c024_clamp(double dcycs, int clamp);
 void mouse_compress_fifo(double dcycs);
 void adb_key_event(int a2code, int is_up);
 word32 adb_read_c000(void);
@@ -350,6 +351,9 @@ void iwm_show_a_track(Trk *trk);
 
 /* moremem.c */
 void moremem_init(); // OG Added moremem_init()
+int mig_changedrive(int);
+void mig_checkwhead(Disk*,int);
+void fixup_mig(void);
 void fixup_brks(void);
 void fixup_hires_on(void);
 void fixup_bank0_2000_4000(void);


### PR DESCRIPTION
This is the gsplus version of the kegs-universal changes. These changes allow kegs (and now gsplus) to operate using all classic apple 2 roms. See <https://github.com/leonbottou/kegs-universal>. The supported roms include:
- Apple 2 and Apple 2+ roms (12KB)
- Apple 2e roms (regular and enhanced, 16KB)
- Apple 2c and 2c+ roms (all five version).

The idea is to add just what's necessary to operate these older roms. The emulated machine essentially remains a 2gs, but with the minimal changes necessary to operate the selected rom. Most of the changes are in file `moremem.c` to support the necessary io-space features of each of these computers. Smaller related changes have been made to `adb.c`, `config.c`, `defs_instr.c`, `iwm.c`, `sim68516.c`,  and `smartport.c`. (see https://github.com/leonbottou/kegs-universal/blob/master/README.md for details).  Some of these changes actually improve the 2gs emulation (e.g. the language card double reads, the phantom read with instruction `INC abs,X`, the slot powerup scan,...

Despite all these changes, the diff remains readable and explainable. I am intending to add comments to all these diffs to explain what they do and make the review easier.