### PR TITLE
Host fst updates

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -118,6 +118,8 @@ extern int g_win_status_debug_request;
 
 extern char *g_cfg_host_path;
 extern int g_cfg_host_read_only;
+extern int g_cfg_host_crlf;
+extern int g_cfg_host_merlin;
 
 extern int g_screen_index[];
 extern word32 g_full_refresh_needed;
@@ -244,6 +246,8 @@ Cfg_menu g_cfg_host_menu[] = {
 { "Host FST Configuration", g_cfg_host_menu, 0, 0, CFGTYPE_MENU },
 { "Shared Host Folder", KNMP(g_cfg_host_path), CFGTYPE_DIR },
 { "Read Only,0,No,1,Yes", KNMP(g_cfg_host_read_only), CFGTYPE_INT },
+{ "CR/LF conversion,0,No,1,Yes", KNMP(g_cfg_host_crlf), CFGTYPE_INT },
+{ "Merlin conversion,0,No,1,Yes", KNMP(g_cfg_host_merlin), CFGTYPE_INT },
 { "", 0, 0, 0, 0 },
 { "Back to Main Config", g_cfg_main_menu, 0, 0, CFGTYPE_MENU },
 { 0, 0, 0, 0, 0 },

--- a/src/host_fst.c
+++ b/src/host_fst.c
@@ -2607,7 +2607,6 @@ void host_fst(void) {
 			case 0x02:
 			case 0x05:
 			case 0x06:
-			case 0x07:
 			case 0x0b:
 			case 0x10:
 				path1 = get_path1();

--- a/src/host_fst.c
+++ b/src/host_fst.c
@@ -2558,6 +2558,7 @@ void host_fst(void) {
 
 	fprintf(stderr, "Host FST: %04x %s", call, call_name(call));
 
+
 	if (call & 0x8000) {
 		fputs("\n", stderr);
 		// system level.
@@ -2574,14 +2575,27 @@ void host_fst(void) {
 		}
 	} else {
 
+		if (!root) {
+			acc = networkError;
+			engine.acc =  acc;
+			SEC();
+ 			fprintf(stderr, "          %02x   %s\n", acc, error_name(acc));
+
+			return;
+		}
+
 		int class = call >> 13;
 		call &= 0x1fff;
 
 		if (class > 1) {
+			acc = invalidClass;
+			engine.acc = acc;
 			SEC();
-			engine.acc = invalidClass;
+ 			fprintf(stderr, "          %02x   %s\n", acc, error_name(acc));
+
 			return;
 		}
+
 		char *path1 = NULL;
 		char *path2 = NULL;
 		char *path3 = NULL;

--- a/src/win32_host_fst.c
+++ b/src/win32_host_fst.c
@@ -2686,14 +2686,28 @@ void host_fst(void) {
 		}
 	} else {
 
+		if (!root) {
+			acc = networkError;
+			engine.acc =  acc;
+			SEC();
+ 			fprintf(stderr, "          %02x   %s\n", acc, error_name(acc));
+
+			return;
+		}
+
+
 		int class = call >> 13;
 		call &= 0x1fff;
 
 		if (class > 1) {
+			acc = invalidClass;
+			engine.acc = acc;
 			SEC();
-			engine.acc = invalidClass;
+ 			fprintf(stderr, "          %02x   %s\n", acc, error_name(acc));
+
 			return;
 		}
+
 		char *path1 = NULL;
 		char *path2 = NULL;
 		char *path3 = NULL;

--- a/src/win32_host_fst.c
+++ b/src/win32_host_fst.c
@@ -2672,6 +2672,7 @@ void host_fst(void) {
 	fprintf(stderr, "Host FST: %04x %s", call, call_name(call));
 
 	if (call & 0x8000) {
+		fputs("\n", stderr);
 		// system level.
 		switch(call) {
 			case 0x8001:
@@ -2719,7 +2720,6 @@ void host_fst(void) {
 			case 0x02:
 			case 0x05:
 			case 0x06:
-			case 0x07:
 			case 0x0b:
 			case 0x10:
 				path1 = get_path1();


### PR DESCRIPTION

1. if file_type = 0x0f, storage_type = 0x01, create a directory
2. only read pathname if pathname is expected
3. log path for calls that take a path
4. differentiate fileNotFound vs pathNotFound errors.
5. option to automatically translate cr/lf in text/source files
6. option to merlin encode text .S files
7. default file type for common source code files extensions.