### PR TITLE
add unimplemented functions to allow win32 builds to work

### DIFF
--- a/src/win32_host_fst.c
+++ b/src/win32_host_fst.c
@@ -2862,3 +2862,8 @@ void host_fst(void) {
   if (acc) SEC();
   else CLC();
 }
+
+
+// placeholder to build on win32 until it support host MLI
+void host_mli_head() {}
+void host_mli_tail() {}


### PR DESCRIPTION
This fixes the broken builds for win32, since not that platform doesn't have the P8 MLI support in the host FST driver yet.  I'm putting it in the win32 specific object as I don't know what the author's final implementation plans are.  