### PR TITLE
pi build with sdl2

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -33,7 +33,7 @@ specials: 8inst_s 16inst_s 8size 16size 8inst_c 16inst_c size_c size_s
 specials_clean:
 	rm -f 8inst_s 16inst_s 8size 16size 8inst_c 16inst_c size_c size_s
 
-# Linux/OSX SDL builds
+# Linux/OSX/RPi SDL builds
 gsplus: $(OBJECTS) compile_time.o
 	$(LD) $(CCOPTS) $(LDOPTS) $(OBJECTS) compile_time.o $(LDFLAGS) -o $(NAME)$(SUFFIX) $(EXTRA_LIBS)
 	echo $(OBJECTS)

--- a/src/vars_rpilinux_sdl2
+++ b/src/vars_rpilinux_sdl2
@@ -1,0 +1,16 @@
+TARGET = gsplus
+NAME = gsplus
+PERL = perl
+CC = gcc
+LD = g++
+#LD = gcc
+AS = cc
+
+OBJECTS = $(OBJECTS1) $(TFEOBJ) $(ATOBJ) $(PCAPOBJ) $(FSTOBJ) sdl2_driver.o sdl2snd_driver.o
+CCOPTS = -O2 -Wall -fomit-frame-pointer -std=gnu99 -march=armv6
+OPTS = -DGSPLUS_LITTLE_ENDIAN -DHAVE_TFE -DHAVE_ATBRIDGE -DHAVE_SDL -I/usr/include/SDL2 -I/usr/include/freetype2
+
+EXTRA_LIBS = -ldl -lfreetype -lSDL2 -lSDL2_image
+
+XOPTS = -I/usr/X11R6/include
+


### PR DESCRIPTION
This works, but HW acceleration is something you set up separately so that will need to be added later with docs, depending on how Pi users are expected to consume the final product.

https://www.raspberrypi.org/forums/viewtopic.php?t=122525

RetroPie-Setup script to get a working SDL2 installed with HW acceleration
```
 git clone https://github.com/RetroPie/RetroPie-Setup
 cd RetroPie-Setup
 sudo ./retropie_packages.sh sdl2
```