### PR TITLE
resolve builds on windows with new fst objects

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -123,7 +123,7 @@ extern char* g_imagewriter_prop_font;
 extern int g_imagewriter_paper;
 extern int g_imagewriter_banner;
 
-#if defined(_WIN32) || defined(__CYGWIN__) && !defined(WIN_SDL)
+#if defined(_WIN32) && !defined(WIN_SDL) || defined(__CYGWIN__) && !defined(WIN_SDL)
 extern int g_win_show_console_request;
 extern int g_win_status_debug_request;
 #endif
@@ -416,7 +416,7 @@ Cfg_menu g_cfg_imagewriter_menu[] = {
 
 Cfg_menu g_cfg_devel_menu[] = {
   { "Developer Options", g_cfg_devel_menu, 0, 0, CFGTYPE_MENU },
-#if defined(_WIN32) || defined(__CYGWIN__) && !defined(WIN_SDL)
+#if defined(_WIN32) && !defined(WIN_SDL) || defined(__CYGWIN__) && !defined(WIN_SDL)
   { "Status lines,0,Hide,1,Show", KNMP(g_win_status_debug_request), CFGTYPE_INT },
   { "Console,0,Hide,1,Show", KNMP(g_win_show_console_request), CFGTYPE_INT },
 #endif

--- a/src/dis.c
+++ b/src/dis.c
@@ -639,7 +639,8 @@ int read_line(char *buf, int len)     {
   buf[0] = 0;
   ret = 0;
   while(space_left > 0) {
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(WIN_SDL)
+
     ret = win_nonblock_read_stdin(0, buf, 1);
 #else
     /* Unix */

--- a/src/sdl2_driver.c
+++ b/src/sdl2_driver.c
@@ -23,7 +23,9 @@ unsigned int lastTime = 0, currentTime, frames;
 #ifdef HAVE_ICON    // Currently a flag because not supported outside of SDL builds.  Looking at full solution.
   #include "icongs.h"
 #endif
-
+#ifdef _WIN32
+  #include <unistd.h>
+#endif
 // BITMASKS
 #define ShiftMask       1
 #define ControlMask     4

--- a/src/sim65816.c
+++ b/src/sim65816.c
@@ -26,7 +26,7 @@ extern char g_config_gsplus_screenshot_dir[];
   #include "tfe/protos_tfe.h"
 #endif
 
-#if defined (_WIN32) || defined(__CYGWIN__) && !defined(WIN_SDL)
+#if defined (_WIN32) && !defined(WIN_SDL)|| defined(__CYGWIN__) && !defined(WIN_SDL)
   #define WIN32_LEAN_AND_MEAN   /* Tell windows we want less header gunk */
   #define STRICT                        /* Tell Windows we want compile type checks */
   #include <windows.h>          /* Need a definition for LPTSTR in CYGWIN */
@@ -1096,7 +1096,7 @@ void gsport_expand_path(char *out_ptr, const char *in_ptr, int maxlen)      {
         if(!strncmp("0", name_buf, 128)) {
           /* Replace ${0} with g_argv0_path */
           tmp_ptr = &(g_argv0_path[0]);
-#if defined (_WIN32) || defined(__CYGWIN__) && !defined(WIN_SDL)
+#if defined (_WIN32) && !defined(WIN_SDL)|| defined(__CYGWIN__) && !defined(WIN_SDL)
         } else if(!strncmp("PWD", name_buf, 128)) {
           /* Replace ${PWD} with cwd in Windows */
           get_cwd(out_ptr,128);

--- a/src/vars_win32
+++ b/src/vars_win32
@@ -1,6 +1,6 @@
 TARGET = gsplus32.exe
 
-FSTOBJ = win32_host_fst.o
+FSTOBJ = host_common.o win32_host_common.o host_mli.o win32_host_fst.o
 
 OBJECTS = $(OBJECTS1) $(TFEOBJ) $(ATOBJ) $(PCAPOBJ) $(FSTOBJ) scc_windriver.o win32snd_driver.o win_console.o win_generic.o gsplus32.o
 CCOPTS = -O2 -DGSPLUS_LITTLE_ENDIAN -DHAVE_TFE -DWIN_SOUND -DTOGGLE_STATUS -DWIN32 -D_WIN32 -D__USE_W32_SOCKETS -D_WINSOCK2API_ -std=gnu99 -DHAVE_ATBRIDGE

--- a/src/vars_win32_sdl2
+++ b/src/vars_win32_sdl2
@@ -3,12 +3,12 @@ NAME = gsplus
 
 MINGW_HOME = /cygdrive/c/mingw/i686-w64-mingw32
 
-FSTOBJ = win32_host_fst.o
+FSTOBJ = host_common.o win32_host_common.o host_mli.o win32_host_fst.o
 
-OBJECTS = sdl2_driver.o $(OBJECTS1)  $(FSTOBJ) sdl2snd_driver.o
+OBJECTS = sdl2_driver.o $(OBJECTS1)  $(FSTOBJ) sdl2snd_driver.o scc_windriver.o 
 
-CCOPTS = -O3 -DGSPLUS_LITTLE_ENDIAN  -DHAVE_SDL -DWIN_SDL -DTOGGLE_STATUS -I$(MINGW_HOME)/include/SDL2 -DWINSDL_BORDERHACK 
-CPPOPTS = -O3 -DGSPLUS_LITTLE_ENDIAN -DHAVE_SDL -DWIN_SDL -DTOGGLE_STATUS -I/usr/include/freetype2 -I$(MINGW_HOME)/include/SDL2 
+CCOPTS = -O3 -DGSPLUS_LITTLE_ENDIAN -DWIN32 -D_WIN32 -DHAVE_SDL -DWIN_SDL -DTOGGLE_STATUS -I$(MINGW_HOME)/include/SDL2 -DWINSDL_BORDERHACK  -D__USE_W32_SOCKETS -D_WINSOCK2API_ 
+CPPOPTS = -O3 -DGSPLUS_LITTLE_ENDIAN -DWIN32 -D_WIN32 -DHAVE_SDL -DWIN_SDL -DTOGGLE_STATUS -I/usr/include/freetype2 -I$(MINGW_HOME)/include/SDL2  -D__USE_W32_SOCKETS -D_WINSOCK2API_ 
 
 SUFFIX = ".exe"
 # working in cygwin


### PR DESCRIPTION
totally switching up the windows cygwin sdl2 build to get this working.  builds and runs ok.  the ifdefs are a mess, but i think the real issue is that the windows builds suffer from multiple personality disorder.  i've considered doing a win native build with vs.  for now this gets things running again.