### PR TITLE
add vsync flag for great success

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -54,6 +54,8 @@ extern int g_fullscreen;
 extern int g_highdpi;
 extern int g_borderless;
 extern int g_resizeable;
+extern int g_novsync;
+extern int g_nohwaccel;
 extern int g_screen_redraw_skip_amt;
 extern int g_use_dhr140;
 extern int g_use_bw_hires;
@@ -206,6 +208,8 @@ Cfg_menu g_cfg_uiless_menu[] = {
   { "", KNMP(g_highdpi), CFGTYPE_INT },
   { "", KNMP(g_borderless), CFGTYPE_INT },
   { "", KNMP(g_resizeable), CFGTYPE_INT },
+  { "", KNMP(g_novsync), CFGTYPE_INT },
+  { "", KNMP(g_nohwaccel), CFGTYPE_INT },
   { "", KNMP(g_screen_redraw_skip_amt), CFGTYPE_INT },
   { "", KNMP(g_use_dhr140), CFGTYPE_INT },
   { "", KNMP(g_use_bw_hires), CFGTYPE_INT },

--- a/src/options.c
+++ b/src/options.c
@@ -4,7 +4,7 @@
    See COPYRIGHT.txt for Copyright information
    See LICENSE.txt for license (GPL v2)
  */
- 
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -39,6 +39,10 @@ extern int g_highdpi;                 // defined in video.c
 extern int g_borderless;              // defined in video.c
 // Allow window resizing, dragging to scale - SDL2
 extern int g_resizeable;              // defined in video.c
+// Don't explicitly set vsync present flag on renderer - SDL2
+extern int g_novsync;              // defined in video.c
+// Don't explicitly set HW accelerator flag on renderer - SDL2
+extern int g_nohwaccel;              // defined in video.c
 // Enable Dagen's scanline simulator (SDL2)
 extern int g_scanline_simulator;      // defined in sim65816.c
 // Ethernet (interface?)
@@ -133,6 +137,12 @@ int parse_cli_options(int argc, char **argv) {
     } else if(!strcmp("-resizeable", argv[i])) {
       glogf("%s Window will be resizeable", parse_log_prefix);
       g_resizeable = 1;
+    } else if(!strcmp("-novsync", argv[i])) {
+      glogf("%s Renderer skipping vsync flag", parse_log_prefix);
+      g_novsync = 1;
+    } else if(!strcmp("-nohwaccel", argv[i])) {
+      glogf("%s Renderer skipping HW accel flag", parse_log_prefix);
+      g_nohwaccel = 1;
     } else if(!strcmp("-noignbadacc", argv[i])) {
       glogf("%s Not ignoring bad memory accesses", parse_log_prefix);
       g_ignore_bad_acc = 0;

--- a/src/video.c
+++ b/src/video.c
@@ -94,6 +94,8 @@ int g_starty = WINDOWPOS_UNDEFINED;
 int g_highdpi = 0;
 int g_borderless = 0;
 int g_resizeable = 0;
+int g_novsync = 0;
+int g_nohwaccel = 0;
 
 int g_a2_new_all_stat[200];
 int g_a2_cur_all_stat[200];


### PR DESCRIPTION
This adds debug info for what SDL drivers/renderers are being used behind the scenes.  
More importantly, it adds the hint to use VSYNC fixing massive performance issues!  Updates look good on OSX now!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!  60FPS!!!!!!!!!!!!!! 

There are also flags to disable the vsync for testing and in case it causes issues with varying sync rates in the wild.