### PR TITLE
fix sdl frame rendering vsync method to simply present the buffer once per frame

### DIFF
--- a/src/sdl2_driver.c
+++ b/src/sdl2_driver.c
@@ -416,17 +416,9 @@ void sdl_push_kimage(Kimage *kimage_ptr, int destx, int desty, int srcx, int src
     pitch = BORDER_WIDTH+72;
   }
   SDL_UpdateTexture(texture, &dstrect, src_ptr, pitch*4 );
-  SDL_RenderClear(renderer);
-  SDL_RenderCopy(renderer, texture, NULL, NULL);
-  if (g_scanline_simulator) {
-    SDL_RenderCopy(renderer, overlay_texture, NULL, NULL);
-  }
-  SDL_RenderPresent(renderer);
 
-  if (g_screenshot_requested) {
-    x_take_screenshot();
-    g_screenshot_requested = 0;
-  }
+  // We now call the render step seperately in sdl_present_buffer once per frame
+  // SDL picks up the buffer and waits for VBLANK to send it
 }
 
 
@@ -806,6 +798,19 @@ void debuginfo_renderer(SDL_Renderer *r) {
   }
 }
 
+void sdl_present_buffer() {
+  SDL_RenderClear(renderer);
+  SDL_RenderCopy(renderer, texture, NULL, NULL);
+  if (g_scanline_simulator) {
+    SDL_RenderCopy(renderer, overlay_texture, NULL, NULL);
+  }
+
+  SDL_RenderPresent(renderer);
+  if (g_screenshot_requested) {
+    x_take_screenshot();
+    g_screenshot_requested = 0;
+  }
+}
 
 // BELOW ARE FUNCTIONS THAT ARE EITHER UNIMPLEMENTED, OR AR NOT RELEVANT TO
 // THIS DRIVER.

--- a/src/video.c
+++ b/src/video.c
@@ -640,7 +640,10 @@ void video_update() {
     video_update_through_line(0);
   }
 
-
+#if defined(HAVE_SDL)
+  extern void sdl_present_buffer();
+  sdl_present_buffer();
+#endif
 // OG Notify host that video has been uodated
 #if defined(ACTIVEGSPLUGIN) && defined(MAC)
   {
@@ -3473,13 +3476,6 @@ void video_update_color_array(int col_num, int a2_color)      {
   if(!full && palette == g_a2vid_palette) {
     return;
   }
-
-#if 0
-  if(g_screen_depth != 8) {
-    /* redraw whole superhires for now */
-    g_full_refresh_needed = -1;
-  }
-#endif
 
   video_update_color_raw(col_num, a2_color);
 }


### PR DESCRIPTION
This fixes a big bug introduced in the switch to VBLANK lock.  

It was presenting the screen buffer any time a region was changed (screen area, horizontal borders, vertical borders) and waiting for a VBLANK.  If multiple regions changed per frame, it would cause it to wait multiple VBLANK on the host per Apple II vblanks.  

This refactors it to allow those buffer updates to happen on the backing texture, and presents the updated texture only once per frame (aka 60FPS) under all conditions.