### PR TITLE
fflush(stderr)

### DIFF
--- a/src/sim65816.c
+++ b/src/sim65816.c
@@ -1486,6 +1486,7 @@ void run_prog()      {
   int fast, zip_speed, faster_than_28, unl_speed;
   int this_type;
 
+  fflush(stderr);
   fflush(stdout);
 
   g_cur_sim_dtime = 0.0;
@@ -1508,6 +1509,7 @@ void run_prog()      {
   }
 
   while(1) {
+    fflush(stderr);
     fflush(stdout);
 
 // OG Disabling control panel


### PR DESCRIPTION
since MSVCRT's stdio doesn't support line-oriented buffering, as it should.