### PR TITLE
host fst fix when switching to prodos-8

### DIFF
--- a/src/host_fst.c
+++ b/src/host_fst.c
@@ -407,6 +407,10 @@ static char *get_path2(void) {
 }
 
 
+/*
+ * shutdown is called when switching to p8.
+ * startup is ONLY called during initial boot.
+ */
 
 static word32 fst_shutdown(void) {
 
@@ -418,7 +422,7 @@ static word32 fst_shutdown(void) {
     free_fd(head);
     head = next;
   }
-  host_shutdown();
+  //host_shutdown();
   return 0;
 }
 
@@ -426,6 +430,8 @@ static word32 fst_startup(void) {
   // if restart, close any previous files.
 
   fst_shutdown();
+  host_shutdown();
+
   memset(&cookies, 0, sizeof(cookies));
 
   return host_startup();


### PR DESCRIPTION
reported in c.e.a2 - when dropping into p8, fst_shutdown is called.  when returning to gs/os, fst_startup is NOT called.

This effective unmounts the host file system, permanently, since it assumed fst_startup would get called again.

fst_shutdown code now closes any open files but does not otherwise unmount.