### PR TITLE
Merge duplicate logging

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -44,7 +44,6 @@ extern byte *g_rom_fc_ff_ptr;
 extern byte *g_rom_cards_ptr;
 extern double g_cur_dcycs;
 extern int g_rom_version;
-extern int g_fatal_log;
 
 extern word32 g_adb_repeat_vbl;
 
@@ -3183,9 +3182,6 @@ void config_control_panel()      {
   g_cfg_slotdrive = -1;
   g_cfg_select_partition = -1;
   while(g_config_control_panel & !(halt_sim&HALT_WANTTOQUIT)) {
-    if(g_fatal_log > 0) {
-      x_show_alert(0, 0);
-    }
     cfg_home();
     line = 1;
     max_line = 1;

--- a/src/fbdriver.c
+++ b/src/fbdriver.c
@@ -421,7 +421,6 @@ void x_dialog_create_gsport_conf(const char *str) {
 int x_show_alert(int is_fatal, const char *str) {
   // Not implemented yet
   adb_all_keys_up();
-  clear_fatal_logs();
   return 0;
 }
 void x_toggle_status_lines(void) {

--- a/src/glog.c
+++ b/src/glog.c
@@ -14,11 +14,6 @@
 
 extern int x_show_alert(int fatal, const char *str);
 
-#define MAX_FATAL_LOGS          20
-
-int g_fatal_log = 0;
-char *g_fatal_log_strs[MAX_FATAL_LOGS];
-
 int glog(const char *s) {
   time_t timer;
   char buffer[26];
@@ -63,33 +58,12 @@ int fatal_printf(const char *fmt, ...)     {
 
   va_start(ap, fmt);
 
-  if(g_fatal_log < 0) {
-    g_fatal_log = 0;
-  }
-
   ret = vsnprintf(buffer, sizeof(buffer), fmt, ap);
 
   glog(buffer);
 
   x_show_alert(1, buffer);
-  /*
-  if (g_fatal_log < MAX_FATAL_LOGS) {
-    g_fatal_log_strs[g_fatal_log++] = strdup(buffer);
-  }
-  */
 
   va_end(ap);
   return ret;
-}
-
-
-
-void clear_fatal_logs()      {
-  int i;
-
-  for(i = 0; i < g_fatal_log; i++) {
-    free(g_fatal_log_strs[i]);
-    g_fatal_log_strs[i] = 0;
-  }
-  g_fatal_log = 0;
 }

--- a/src/glog.c
+++ b/src/glog.c
@@ -12,6 +12,7 @@
 
 #include "glog.h"
 
+extern int x_show_alert(int fatal, const char *str);
 
 #define MAX_FATAL_LOGS          20
 
@@ -70,10 +71,12 @@ int fatal_printf(const char *fmt, ...)     {
 
   glog(buffer);
 
+  x_show_alert(1, buffer);
+  /*
   if (g_fatal_log < MAX_FATAL_LOGS) {
     g_fatal_log_strs[g_fatal_log++] = strdup(buffer);
   }
-
+  */
 
   va_end(ap);
   return ret;

--- a/src/glog.c
+++ b/src/glog.c
@@ -4,11 +4,19 @@
    See COPYRIGHT.txt for Copyright information
    See LICENSE.txt for license (GPL v2)
  */
-#include <stdio.h>
-#include <time.h>
 #include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
 
 #include "glog.h"
+
+
+#define MAX_FATAL_LOGS          20
+
+int g_fatal_log = 0;
+char *g_fatal_log_strs[MAX_FATAL_LOGS];
 
 int glog(const char *s) {
   time_t timer;
@@ -44,4 +52,41 @@ int glogf(const char *fmt, ...) {
   va_end(ap);
   fputc('\n', stdout);
   return 0;
+}
+
+
+int fatal_printf(const char *fmt, ...)     {
+  static char buffer[4096];
+  va_list ap;
+  int ret;
+
+  va_start(ap, fmt);
+
+  if(g_fatal_log < 0) {
+    g_fatal_log = 0;
+  }
+
+  ret = vsnprintf(buffer, sizeof(buffer), fmt, ap);
+
+  glog(buffer);
+
+  if (g_fatal_log < MAX_FATAL_LOGS) {
+    g_fatal_log_strs[g_fatal_log++] = strdup(buffer);
+  }
+
+
+  va_end(ap);
+  return ret;
+}
+
+
+
+void clear_fatal_logs()      {
+  int i;
+
+  for(i = 0; i < g_fatal_log; i++) {
+    free(g_fatal_log_strs[i]);
+    g_fatal_log_strs[i] = 0;
+  }
+  g_fatal_log = 0;
 }

--- a/src/glog.h
+++ b/src/glog.h
@@ -5,7 +5,6 @@ extern "C" {
   int glogf(const char *s, ...);
 
   int fatal_printf(const char *fmt, ...);
-  void clear_fatal_logs(void);
 
 #ifdef __cplusplus
 }

--- a/src/glog.h
+++ b/src/glog.h
@@ -3,6 +3,10 @@ extern "C" {
 #endif
   int glog(const char *s);
   int glogf(const char *s, ...);
+
+  int fatal_printf(const char *fmt, ...);
+  void clear_fatal_logs(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/protos.h
+++ b/src/protos.h
@@ -403,10 +403,6 @@ void do_wdm(word32 arg);
 void do_wai(void);
 void do_stp(void);
 void size_fail(int val, word32 v1, word32 v2);
-int fatal_printf(const char *fmt, ...);
-int gsport_vprintf(const char *fmt, va_list ap);
-void must_write(int fd, char *bufptr, int len);
-void clear_fatal_logs(void);
 char *gsplus_malloc_str(char *in_str);
 
 

--- a/src/scc_socket_driver.c
+++ b/src/scc_socket_driver.c
@@ -9,6 +9,8 @@
 
 #include "defc.h"
 #include "scc.h"
+#include "glog.h"
+
 #include <string.h>
 #include <stdlib.h>
 #ifndef UNDER_CE        //OG

--- a/src/scc_socket_driver.c
+++ b/src/scc_socket_driver.c
@@ -226,7 +226,6 @@ void scc_socket_open_outgoing(int port, double dcycs) {
 #endif
     scc_socket_close_handle(sockfd);
     scc_socket_close(port, 1, dcycs);
-    x_show_alert(0, 0);
     return;
   }
   memcpy(&sa_in.sin_addr.s_addr, hostentptr->h_addr,

--- a/src/sim65816.c
+++ b/src/sim65816.c
@@ -196,11 +196,7 @@ int g_engine_doc_int = 0;
 
 int g_testing = 0;
 
-#define MAX_FATAL_LOGS          20
 
-int g_debug_file_fd = -1;
-int g_fatal_log = -1;
-char *g_fatal_log_strs[MAX_FATAL_LOGS];
 
 word32 stop_run_at;
 
@@ -288,9 +284,6 @@ void sim65816_initglobals() {
   g_engine_doc_int = 0;
 
   g_testing = 0;
-
-  g_debug_file_fd = -1;
-  g_fatal_log = -1;
 
   g_25sec_cntr = 0;
   g_1sec_cntr = 0;
@@ -2571,70 +2564,7 @@ void size_fail(int val, word32 v1, word32 v2)      {
   halt_printf("Size failure, val: %08x, %08x %08x\n", val, v1, v2);
 }
 
-int gsplus_vprintf(const char *fmt, va_list ap)     {
-  char    *bufptr, *buf2ptr;
-  int len;
-  int ret;
 
-  bufptr = (char*)malloc(4096);       // OG Added Cast
-  ret = vsnprintf(bufptr, 4090, fmt, ap);
-
-  // OG Display warning
-  printf("Warning:%s",bufptr);
-
-  len = strlen(bufptr);
-  if(g_fatal_log >= 0 && g_fatal_log < MAX_FATAL_LOGS) {
-    buf2ptr = (char*)malloc(len+1);             // OG Added Cast
-    memcpy(buf2ptr, bufptr, len+1);
-    g_fatal_log_strs[g_fatal_log++] = buf2ptr;
-  }
-  must_write(1, bufptr, len);
-  if(g_debug_file_fd >= 0) {
-    must_write(g_debug_file_fd, bufptr, len);
-  }
-  free(bufptr);
-
-  return ret;
-}
-
-
-int fatal_printf(const char *fmt, ...)     {
-  va_list ap;
-  int ret;
-
-  va_start(ap, fmt);
-
-  if(g_fatal_log < 0) {
-    g_fatal_log = 0;
-  }
-  ret = gsplus_vprintf(fmt, ap);
-  va_end(ap);
-
-  return ret;
-}
-
-void must_write(int fd, char *bufptr, int len)      {
-  int ret;
-  while(len > 0) {
-    ret = write(fd, bufptr, len);
-    if(ret >= 0) {
-      len -= ret;
-      bufptr += ret;
-    } else if(errno != EAGAIN && errno != EINTR) {
-      return;                           // just get out
-    }
-  }
-}
-
-void clear_fatal_logs()      {
-  int i;
-
-  for(i = 0; i < g_fatal_log; i++) {
-    free(g_fatal_log_strs[i]);
-    g_fatal_log_strs[i] = 0;
-  }
-  g_fatal_log = -1;
-}
 
 char *gsplus_malloc_str(char *in_str)       {
   char    *str;

--- a/src/sim65816.c
+++ b/src/sim65816.c
@@ -1011,7 +1011,6 @@ int gsplusmain(int argc, char **argv) {
   iwm_shut();
   fixed_memory_ptrs_shut();
   load_roms_shut_memory();
-  clear_fatal_logs();
 
   // OG Not needed anymore : the emulator will quit gently
   //my_exit(0);
@@ -1184,8 +1183,6 @@ void setup_gsplus_file(char *outname, int maxlen, int ok_if_missing, int can_cre
     x_dialog_create_gsport_conf(*name_ptr);
     can_create_file = 0;
 
-    // But clear out the fatal_printfs first
-    clear_fatal_logs();
     setup_gsplus_file(outname, maxlen, ok_if_missing,       can_create_file, name_ptr);
     // It's one-level of recursion--it cannot loop since we
     //  clear can_create_file.

--- a/src/win_console.c
+++ b/src/win_console.c
@@ -58,6 +58,7 @@ void x_dialog_create_gsport_conf(const char *str)      {
 int x_show_alert(int is_fatal, const char *str) {
 
   if (str && *str) {
+    adb_all_keys_up();
     MessageBox(NULL, str, "GS+", is_fatal ? MB_ICONERROR : MB_ICONWARNING);
   }
   return 0;
@@ -143,10 +144,6 @@ int main(int argc, char **argv)     {
                              size.cx, size.cy,
                              NULL, NULL, GetModuleHandle(NULL), NULL);
 
-  printf("g_hwnd_main = %p, height = %d\n", hwnd, size.cx);
-  GetWindowRect(hwnd, &rect);
-  printf("...rect is: %ld, %ld, %ld, %ld\n", rect.left, rect.top,
-         rect.right, rect.bottom);
 
   // Enable non-blocking, character-at-a-time console I/O.
   // win_nonblock_read_stdin() expects this behavior.

--- a/src/win_console.c
+++ b/src/win_console.c
@@ -55,7 +55,11 @@ void x_dialog_create_gsport_conf(const char *str)      {
   config_write_config_gsplus_file();
 }
 
-int x_show_alert(int is_fatal, const char *str)     {
+int x_show_alert(int is_fatal, const char *str) {
+
+  if (str && *str) {
+    MessageBox(NULL, str, "GS+", is_fatal ? MB_ICONERROR : MB_ICONWARNING);
+  }
   return 0;
 }
 

--- a/src/xdriver.c
+++ b/src/xdriver.c
@@ -254,7 +254,6 @@ int x_show_alert(int is_fatal, const char *str) {
   /* Not implemented yet */
   adb_all_keys_up();
 
-  clear_fatal_logs();
   return 0;
 }
 


### PR DESCRIPTION
this started out by noticing there was duplicate logging functionality in the form of `fatal_printf`, so it was moved to `glog.c` and cleaned up a bit to show an error alert immediately.  the g_fatal_log array and all the extra work that goes with it was eliminated as well. 