### PR TITLE
fix macos dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An Apple IIgs emulator based on KEGS
 # Build instructions
 
 ## OS X dependencies
-    brew install re2c sdl2 sdl2_image freetype
+    brew install cmake pkg-config re2c sdl2 sdl2_image freetype
 
 ## Linux dependencies
     apt-get install re2c libsdl2-dev libsdl2-image-dev libfreetype6-dev libpcap0.8-dev

--- a/doc/Developer-QuickStart-MacOSX.txt
+++ b/doc/Developer-QuickStart-MacOSX.txt
@@ -14,7 +14,7 @@ xcode-select --install
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
 # Use brew to install dependencies.
-brew install sdl2 sdl2_image freetype re2c cmake
+brew install cmake pkg-config re2c sdl2 sdl2_image freetype
 
 # Clone & Build.
 git clone git@github.com:digarok/gsplus.git


### PR DESCRIPTION
Needs cmake and pkg-config to build on macos (still possible without
pkg-config by using ccmake and adding sdl2/freetype flags/libraries manually, which
is a pain.)