### PR TITLE
Add posix timing as clock ticks for non x86 systems

### DIFF
--- a/src/engine_c.c
+++ b/src/engine_c.c
@@ -884,6 +884,15 @@ void fixed_memory_ptrs_shut() {
 
   #if defined(__i386__) ||  defined(__x86_64__)
     #include <x86intrin.h>
+  #elif defined(_POSIX_MONOTONIC_CLOCK)
+    #include <time.h>
+    int64_t __rdtsc() {
+      struct timespec tp = {0};
+      int64_t timestamp = 0;
+      if (clock_gettime(CLOCK_MONOTONIC, &tp) == 0)
+        timestamp = tp.tv_sec * 1000000000 + tp.tv_nsec;
+      return timestamp;
+    }
   #elif defined(__powerpc__) || defined(__ppc__)
     #define __rdtsc() __builtin_ppc_mftb()
   #else


### PR DESCRIPTION
Hi,

This is what happens when i try to build gsplus on my OpenBSD/macppc box:
```
/usr/obj/ports/gsplus-20190816/gsplus-480572054518112647c8fae5d7ea7046a6d6ecfb/src/engine_c.c:905:10: error: use of unknown builtin '__builtin_ppc_mftb' [-Wimplicit-function-declaration]
  return __rdtsc();
```
OpenBSD uses clang on powerpc, `__builtin_ppc_mftb()` is a gcc-ism.  As such i'm proposing to add posix timings on systems that support it, not only this is more portable, but would allow more architectures to use it; this is how [retroarch](
https://github.com/libretro/RetroArch/pull/10383) does it for example.

It can't be extended as-is to x86 because `__rtsdc()` is a native builtin, the #define should be renamed to do so, which would require a more intrusive patch.

cc @rapenne-s